### PR TITLE
Changed docs from cOS to Elemental

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -29,9 +29,9 @@ identifier = "matrix"
 url = "https://matrix.to/#/#c3os:matrix.org"
 weight = 1
 [[Languages.en.menu.shortcuts]]
-name = "<i class='fas fa-fw fa-bookmark'></i> cOS Documentation"
+name = "<i class='fas fa-fw fa-bookmark'></i> Element Documentation"
 identifier = "hugodoc"
-url = "https://rancher-sandbox.github.io/cos-toolkit-docs/docs"
+url = "https://rancher.github.io/elemental-toolkit/docs"
 weight = 20
 
 [outputs]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -29,7 +29,7 @@ identifier = "matrix"
 url = "https://matrix.to/#/#c3os:matrix.org"
 weight = 1
 [[Languages.en.menu.shortcuts]]
-name = "<i class='fas fa-fw fa-bookmark'></i> Element Documentation"
+name = "<i class='fas fa-fw fa-bookmark'></i> Elemental-toolkit Documentation"
 identifier = "hugodoc"
 url = "https://rancher.github.io/elemental-toolkit/docs"
 weight = 20

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -28,5 +28,5 @@ c3OS have:
 c3OS is composed of:
 - [k3s](https://k3s.io) as a Kubernetes distribution
 - [edgevpn](https://mudler.github.io/edgevpn) as fabric for the distributed network, node coordination and bootstrap. Provides also embedded DNS capabilities for the cluster.
-- [element-toolkit](https://rancher.github.io/elemental-toolkit/docs/) as a fundament to build the Linux derivative. Indeed, any `Element` docs applies to `c3os` as well.
+- [element-toolkit](https://rancher.github.io/elemental-toolkit/docs/) as a fundament to build the Linux derivative. Indeed, any `Elemental` docs applies to `c3os` as well.
 - [nohang](https://github.com/hakavlad/nohang) A sophisticated low memory handler for Linux 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -28,5 +28,5 @@ c3OS have:
 c3OS is composed of:
 - [k3s](https://k3s.io) as a Kubernetes distribution
 - [edgevpn](https://mudler.github.io/edgevpn) as fabric for the distributed network, node coordination and bootstrap. Provides also embedded DNS capabilities for the cluster.
-- [cOS-toolkit](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/) as a fundament to build the Linux derivative. Indeed, any `cOS` docs applies to `c3os` as well.
+- [element-toolkit](https://rancher.github.io/elemental-toolkit/docs/) as a fundament to build the Linux derivative. Indeed, any `Element` docs applies to `c3os` as well.
 - [nohang](https://github.com/hakavlad/nohang) A sophisticated low memory handler for Linux 

--- a/docs/content/after_install/recovery_mode.md
+++ b/docs/content/after_install/recovery_mode.md
@@ -9,7 +9,7 @@ pre = "<b>- </b>"
 The c3os recovery mode can be used to recover a damaged system, or to regain access remotely (with assistance) to a machine which has been lost access to. The recovery mode is accessible only from the GRUB menu, from both the LiveCD and an installed system.
 
 {{% notice note %}}
-On installed system there are two recovery modes available during boot. Below it is described only how the c3os remote recovery works. The manual recovery entry has nothing special from the standard cOS recovery mode. It can be used to reset the A/B partitions (with the user/pass used during setup) and perform any other operation without remote access.
+On installed system there are two recovery modes available during boot. Below it is described only how the c3os remote recovery works. The manual recovery entry has nothing special from the standard Element recovery mode. It can be used to reset the A/B partitions (with the user/pass used during setup) and perform any other operation without remote access.
 {{% /notice %}}
 
 ## Boot into recovery mode

--- a/docs/content/after_install/recovery_mode.md
+++ b/docs/content/after_install/recovery_mode.md
@@ -9,7 +9,7 @@ pre = "<b>- </b>"
 The c3os recovery mode can be used to recover a damaged system, or to regain access remotely (with assistance) to a machine which has been lost access to. The recovery mode is accessible only from the GRUB menu, from both the LiveCD and an installed system.
 
 {{% notice note %}}
-On installed system there are two recovery modes available during boot. Below it is described only how the c3os remote recovery works. The manual recovery entry has nothing special from the standard Element recovery mode. It can be used to reset the A/B partitions (with the user/pass used during setup) and perform any other operation without remote access.
+On installed system there are two recovery modes available during boot. Below it is described only how the c3os remote recovery works. The manual recovery entry has nothing special from the standard Elemental-toolkit recovery mode. It can be used to reset the A/B partitions (with the user/pass used during setup) and perform any other operation without remote access.
 {{% /notice %}}
 
 ## Boot into recovery mode

--- a/docs/content/after_install/upgrades.md
+++ b/docs/content/after_install/upgrades.md
@@ -7,7 +7,7 @@ pre = "<b>- </b>"
 
 ## Kubernetes
 
-Upgrades can be triggered from Kubernetes with `system-upgrade-controller` installed in your cluster. [See the Element documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#integration-with-system-upgrade-controller)
+Upgrades can be triggered from Kubernetes with `system-upgrade-controller` installed in your cluster. [See the Elemental-toolkit documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#integration-with-system-upgrade-controller)
 
 
 System upgrade controller needs to be installed in the cluster which is targeted for the upgrades, for example:
@@ -70,7 +70,7 @@ c3os upgrade <version>
 
 Use `--force` to force upgrading to avoid checking versions. All the available versions can be list with: `c3os upgrade list-releases`.
 
-It is possible altough to use the same commandset from `Element`. So for example, the following works too:
+It is possible altough to use the same commandset from `Elemental-toolkit`. So for example, the following works too:
 
 ```bash
 elemental upgrade --no-verify --docker-image quay.io/c3os/c3os:opensuse-v1.21.4-22
@@ -78,4 +78,4 @@ elemental upgrade --no-verify --docker-image quay.io/c3os/c3os:opensuse-v1.21.4-
 
 c3os images are released on [quay.io](https://quay.io/repository/c3os/c3os).
 
-[See also the general Element documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#upgrade-to-a-specific-container-image) which applies for `c3os` as well.
+[See also the general Elemental-toolkit documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#upgrade-to-a-specific-container-image) which applies for `c3os` as well.

--- a/docs/content/after_install/upgrades.md
+++ b/docs/content/after_install/upgrades.md
@@ -7,7 +7,7 @@ pre = "<b>- </b>"
 
 ## Kubernetes
 
-Upgrades can be triggered from Kubernetes with `system-upgrade-controller` installed in your cluster. [See the cOS documentation](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/getting-started/upgrading/#integration-with-system-upgrade-controller)
+Upgrades can be triggered from Kubernetes with `system-upgrade-controller` installed in your cluster. [See the Element documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#integration-with-system-upgrade-controller)
 
 
 System upgrade controller needs to be installed in the cluster which is targeted for the upgrades, for example:
@@ -70,7 +70,7 @@ c3os upgrade <version>
 
 Use `--force` to force upgrading to avoid checking versions. All the available versions can be list with: `c3os upgrade list-releases`.
 
-It is possible altough to use the same commandset from `cOS`. So for example, the following works too:
+It is possible altough to use the same commandset from `Element`. So for example, the following works too:
 
 ```bash
 elemental upgrade --no-verify --docker-image quay.io/c3os/c3os:opensuse-v1.21.4-22
@@ -78,4 +78,4 @@ elemental upgrade --no-verify --docker-image quay.io/c3os/c3os:opensuse-v1.21.4-
 
 c3os images are released on [quay.io](https://quay.io/repository/c3os/c3os).
 
-[See also the general cOS documentation](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/getting-started/upgrading/#upgrade-to-a-specific-container-image) which applies for `c3os` as well.
+[See also the general Element documentation](https://rancher.github.io/elemental-toolkit/docs/getting-started/upgrading/#upgrade-to-a-specific-container-image) which applies for `c3os` as well.

--- a/docs/content/basics/cli.md
+++ b/docs/content/basics/cli.md
@@ -61,7 +61,7 @@ c3os:
   poweroff: false
 
 # Cloud init syntax to setup users. 
-# See https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/cloud_init/
+# See https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/
 stages:
    network:
      - name: "Setup users"
@@ -91,7 +91,7 @@ c3os:
   poweroff: false
 
 # Cloud init syntax to setup users. 
-# See https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/cloud_init/
+# See https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/
 stages:
    network:
      - name: "Setup users"

--- a/docs/content/basics/layout.md
+++ b/docs/content/basics/layout.md
@@ -5,7 +5,7 @@ weight = 2
 pre = "<b>- </b>"
 +++
 
-c3OS is an immutable Distribution, built with the [cOS-toolkit](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/).
+c3OS is an immutable Distribution, built with the [Element-toolkit](https://rancher.github.io/elemental-toolkit/docs/).
 
 By default, `c3OS` uses an immutable setup.
 
@@ -19,4 +19,4 @@ A running system will look like as follows:
 / immutable
 ```
 
-[See also cOS docs](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/immutable_rootfs/).
+[See also Element docs](https://rancher.github.io/elemental-toolkit/docs/reference/immutable_rootfs/).

--- a/docs/content/basics/layout.md
+++ b/docs/content/basics/layout.md
@@ -5,7 +5,7 @@ weight = 2
 pre = "<b>- </b>"
 +++
 
-c3OS is an immutable Distribution, built with the [Element-toolkit](https://rancher.github.io/elemental-toolkit/docs/).
+c3OS is an immutable Distribution, built with the [Elemental-toolkit](https://rancher.github.io/elemental-toolkit/docs/).
 
 By default, `c3OS` uses an immutable setup.
 
@@ -19,4 +19,4 @@ A running system will look like as follows:
 / immutable
 ```
 
-[See also Element docs](https://rancher.github.io/elemental-toolkit/docs/reference/immutable_rootfs/).
+[See also Elemental-toolkit docs](https://rancher.github.io/elemental-toolkit/docs/reference/immutable_rootfs/).

--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -73,7 +73,7 @@ stages:
 
 ## Syntax
 
-`c3os` supports the standard cloud-init syntax and the extended one from the [Element toolkit](https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/).
+`c3os` supports the standard cloud-init syntax and the extended one from the [Elemental-toolkit](https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/).
 
 Examples using the extended notation for running k3s as agent or server are in [examples](https://github.com/c3os-io/c3os/tree/master/examples). 
 

--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -61,7 +61,7 @@ k3s-agent:
   # replace_args: true
 
 # Cloud init syntax to setup users. 
-# See https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/cloud_init/
+# See https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/
 stages:
    network:
      - name: "Setup users"
@@ -73,7 +73,7 @@ stages:
 
 ## Syntax
 
-`c3os` supports the standard cloud-init syntax and the extended one from the [cOS toolkit](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/cloud_init/).
+`c3os` supports the standard cloud-init syntax and the extended one from the [Element toolkit](https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/).
 
 Examples using the extended notation for running k3s as agent or server are in [examples](https://github.com/c3os-io/c3os/tree/master/examples). 
 

--- a/docs/content/installation/device_pairing.md
+++ b/docs/content/installation/device_pairing.md
@@ -50,7 +50,7 @@ If you are creating a new cluster, you need to create a new network token with t
 {{% /notice %}}
 
 
-The configuration config file is in [cloud-init](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/reference/cloud_init/) syntax and you can customize it further to setup the machine behavior.
+The configuration config file is in [cloud-init](https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/) syntax and you can customize it further to setup the machine behavior.
 
 ## Pair the machine
 

--- a/docs/content/installation/takeover.md
+++ b/docs/content/installation/takeover.md
@@ -6,7 +6,7 @@ chapter = false
 pre = "<b>- </b>"
 +++
 
-`c3os` supports takeover installations, see also [the Element docs](https://rancher.github.io/elemental-toolkit/docs/getting-started/install/#installation-from-3rd-party-livecd-or-rescue-mediums) here are few summarized steps:
+`c3os` supports takeover installations, see also [the Elemental-toolkit docs](https://rancher.github.io/elemental-toolkit/docs/getting-started/install/#installation-from-3rd-party-livecd-or-rescue-mediums) here are few summarized steps:
 
 - From the Dedicated control panel (OVH, Hetzner, etc.), boot in rescue mode
 - [install docker](https://docs.docker.com/engine/install/debian/) and run for example:

--- a/docs/content/installation/takeover.md
+++ b/docs/content/installation/takeover.md
@@ -6,7 +6,7 @@ chapter = false
 pre = "<b>- </b>"
 +++
 
-`c3os` supports takeover installations, see also [the cOS docs](https://rancher-sandbox.github.io/cos-toolkit-docs/docs/getting-started/install/#installation-from-3rd-party-livecd-or-rescue-mediums) here are few summarized steps:
+`c3os` supports takeover installations, see also [the Element docs](https://rancher.github.io/elemental-toolkit/docs/getting-started/install/#installation-from-3rd-party-livecd-or-rescue-mediums) here are few summarized steps:
 
 - From the Dedicated control panel (OVH, Hetzner, etc.), boot in rescue mode
 - [install docker](https://docs.docker.com/engine/install/debian/) and run for example:


### PR DESCRIPTION
This pr changes all cOS I could find to element.
The old cOS links are dead as of 13.06.2022 and the README.md states
https://github.com/c3os-io/c3os/blob/c83a3466f97514c79069ce32d5e6617d40cd8f44/README.md?plain=1#L20-L22