### PR TITLE
Support builds from behind a proxy

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,15 @@ docker build --build-arg C3OS_VERSION=$C3OS_VERSION \
              --build-arg LUET_VERSION=$LUET_VERSION \
              --build-arg OS_LABEL=$OS_LABEL \
              --build-arg OS_NAME=$OS_NAME \
+             --build-arg https_proxy \
+             --build-arg http_proxy \
+             --build-arg no_proxy \
              -t $IMAGE \
              -f images/Dockerfile.${FLAVOR} ./
 
 docker run -v $PWD:/cOS \
            -v /var/run:/var/run \
+           -e https_proxy -e http_proxy -e no_proxy \
            -i --rm quay.io/costoolkit/elemental:v0.0.15-8a78e6b --name $ISO --debug build-iso --date=false --local --overlay-iso /cOS/overlay/files-iso $IMAGE --output /cOS/
 
 # See: https://github.com/rancher/elemental-cli/issues/228


### PR DESCRIPTION
Trying to run `./build.sh` at the office, I quickly found out that building from behind a proxy didn't work.

This fixes that as long as the `https_proxy`, `http_proxy` and `no_proxy` environment variables are set appropriately for the environment where the build is performed.  Any of these variables can be left unset if not needed.