### PR TITLE
swiched image naming scheme

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -38,11 +38,11 @@ jobs:
       - name: Build  🔧
         env:
           FLAVOR: ${{ matrix.flavor }}
-          IMAGE: quay.io/c3os/c3os:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/c3os-${{ matrix.flavor }}:latest
           MODEL: ${{ matrix.model }}
         run: |
           export TAG=${GITHUB_REF##*/}
-          IMAGE_NAME=c3os-$FLAVOR-$TAG.img IMAGE=quay.io/c3os/c3os:$FLAVOR-$TAG bash build.sh all-arm
+          IMAGE_NAME=c3os-$FLAVOR-$TAG.img IMAGE=quay.io/c3os/c3os-$FLAVOR:$TAG bash build.sh all-arm
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/image-corelight.yaml
+++ b/.github/workflows/image-corelight.yaml
@@ -46,17 +46,18 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         env:
+          VARIANT: ${{ matrix.variant }}
           FLAVOR: ${{ matrix.flavor }}
-          IMAGE: quay.io/c3os/${{ matrix.variant }}:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/${{ matrix.variant }}-${{ matrix.flavor }}:latest
           WITH_CLI: ${{ matrix.with_cli }}
           WITH_PROVIDER: ${{ matrix.with_provider }}
         run: |
-          ./earthly.sh +docker --WITH_K3S=false --IMAGE=${IMAGE} --FLAVOR=${FLAVOR} --C3OS_VERSION=latest --WITH_CLI=${WITH_CLI} --WITH_PROVIDER=${WITH_PROVIDER}
+          ./earthly.sh +docker --WITH_K3S=false --IMAGE=${IMAGE} --VARIANT=${VARIANT} --FLAVOR=${FLAVOR} --C3OS_VERSION=latest --WITH_CLI=${WITH_CLI} --WITH_PROVIDER=${WITH_PROVIDER}
       - name: Push to quay
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:
           COSIGN_EXPERIMENTAL: 1
-          IMAGE: quay.io/c3os/${{ matrix.variant }}:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/${{ matrix.variant }}-${{ matrix.flavor }}:latest
         run: | 
           docker push ${IMAGE}
           cosign sign ${IMAGE}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build  🔧
         env:
           FLAVOR: ${{ matrix.flavor }}
-          IMAGE: quay.io/c3os/c3os:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/c3os-${{ matrix.flavor }}:latest
         run: |
           bash build.sh
           sudo mv build/* .
@@ -78,11 +78,11 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
         run: | 
-          docker push quay.io/c3os/c3os:${{ matrix.flavor }}-latest
-          cosign sign quay.io/c3os/c3os:${{ matrix.flavor }}-latest
+          docker push quay.io/c3os/c3os-${{ matrix.flavor }}:latest
+          cosign sign quay.io/c3os/c3os-${{ matrix.flavor }}:latest
       - name: Push to testing
         run: | 
-          docker tag quay.io/c3os/c3os:${{ matrix.flavor }}-latest ttl.sh/c3os-${{ matrix.flavor }}-${{ github.sha }}:8h
+          docker tag quay.io/c3os/c3os-${{ matrix.flavor }}:latest ttl.sh/c3os-${{ matrix.flavor }}-${{ github.sha }}:8h
           docker push ttl.sh/c3os-${{ matrix.flavor }}-${{ github.sha }}:8h
 # Test start
   build-vm-images:

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -47,12 +47,12 @@ jobs:
       - name: Build  🔧
         env:
           FLAVOR: ${{ matrix.flavor }}
-          IMAGE: quay.io/c3os/c3os:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/c3os-${{ matrix.flavor }}:latest
           MODEL: ${{ matrix.model }}
         run: |
           export TAG=${GITHUB_REF##*/}
-          IMAGE_NAME=c3os-$FLAVOR-$TAG.img IMAGE=quay.io/c3os/c3os:$FLAVOR-$TAG bash build.sh all-arm
-          docker push quay.io/c3os/c3os:$FLAVOR-$TAG
+          IMAGE_NAME=c3os-$FLAVOR-$TAG.img IMAGE=quay.io/c3os/c3os-$FLAVOR:$TAG bash build.sh all-arm
+          docker push quay.io/c3os/c3os-$FLAVOR:$TAG
       - name: Push  🔧
         if: startsWith(github.ref, 'refs/tags/')
         env:
@@ -62,15 +62,15 @@ jobs:
         run: |
           export TAG=${GITHUB_REF##*/}
           export IMAGE_NAME=c3os-$FLAVOR-$TAG.img
-          export IMAGE=quay.io/c3os/c3os:$FLAVOR-$TAG
-          docker push quay.io/c3os/c3os:$FLAVOR-$TAG
+          export IMAGE=quay.io/c3os/c3os-$FLAVOR:$TAG
+          docker push quay.io/c3os/c3os-$FLAVOR:$TAG
       - name: Sign image
         if: startsWith(github.ref, 'refs/tags/')
         env:
           COSIGN_EXPERIMENTAL: 1
         run: | 
           TAG=${GITHUB_REF##*/}
-          cosign sign quay.io/c3os/c3os:${{ matrix.flavor }}-$TAG
+          cosign sign quay.io/c3os/c3os-${{ matrix.flavor }}:$TAG
       - name: Export version
         run: |
              TAG=${GITHUB_REF##*/}
@@ -79,9 +79,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           sudo tar cvf build.tar build
-          sudo luet util pack quay.io/c3os/c3os:${{ matrix.flavor }}-$VERSION.img build.tar image.tar
+          sudo luet util pack quay.io/c3os/c3os-${{ matrix.flavor }}:$VERSION.img build.tar image.tar
           sudo -E docker load -i image.tar
-          sudo -E docker push quay.io/c3os/c3os:${{ matrix.flavor }}-$VERSION.img
+          sudo -E docker push quay.io/c3os/c3os-${{ matrix.flavor }}:$VERSION.img
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           FLAVOR: ${{ matrix.flavor }}
-          IMAGE: quay.io/c3os/c3os:${{ matrix.flavor }}-latest
+          IMAGE: quay.io/c3os/c3os-${{ matrix.flavor }}:latest
         run: |
           export TAG=${GITHUB_REF##*/}
-          ISO=c3os-$FLAVOR-$TAG IMAGE=quay.io/c3os/c3os:$FLAVOR-$TAG bash build.sh
+          ISO=c3os-$FLAVOR-$TAG IMAGE=quay.io/c3os/c3os-$FLAVOR:$TAG bash build.sh
           sudo mv build release
       - name: Push to quay
         if: startsWith(github.ref, 'refs/tags/')
@@ -48,8 +48,8 @@ jobs:
           COSIGN_EXPERIMENTAL: 1
         run: | 
           TAG=${GITHUB_REF##*/}
-          docker push quay.io/c3os/c3os:${{ matrix.flavor }}-$TAG
-          cosign sign quay.io/c3os/c3os:${{ matrix.flavor }}-$TAG
+          docker push quay.io/c3os/c3os-${{ matrix.flavor }}:$TAG
+          cosign sign quay.io/c3os/c3os-${{ matrix.flavor }}:$TAG
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,8 @@
 VERSION 0.6
 FROM alpine
+ARG VARIANT=c3os # core, lite, framework
 ARG FLAVOR=opensuse
-ARG IMAGE=quay.io/c3os/c3os:${FLAVOR}-latest
+ARG IMAGE=quay.io/c3os/${VARIANT}-${FLAVOR}:latest
 ARG LUET_VERSION=0.32.4
 ARG OS_ID=c3os
 


### PR DESCRIPTION
images now follow `quay.io/c3os/<variant>-<flavor>:<version>`.  Given framework images are only for internal use I did not change their naming schema.