### PR TITLE
add support for json serialziation of cluster objects

### DIFF
--- a/sdk/clusterplugin/config.go
+++ b/sdk/clusterplugin/config.go
@@ -17,6 +17,16 @@ func (n *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+func (n *Role) MarshalJSON() ([]byte, error) {
+	return []byte(*n), nil
+}
+
+func (n *Role) UnmarshalJSON(val []byte) error {
+	*n = Role(val)
+
+	return nil
+}
+
 const (
 	// RoleInit denotes a special `RoleControlPlane` that can run special tasks to initialize the cluster.  There will only ever be one node with this role in a cluster.
 	RoleInit = "init"
@@ -30,18 +40,18 @@ const (
 
 type Cluster struct {
 	// ClusterToken is a unique string that can be used to distinguish different clusters on networks with multiple clusters.
-	ClusterToken string `yaml:"cluster_token,omitempty"`
+	ClusterToken string `yaml:"cluster_token,omitempty" json:"cluster_token,omitempty"`
 
 	// ControlPlaneHost is a host that all nodes can resolve and use for node registration.
-	ControlPlaneHost string `yaml:"control_plane_host,omitempty"`
+	ControlPlaneHost string `yaml:"control_plane_host,omitempty" json:"control_plane_host,omitempty"`
 
 	// Role informs the sdk what kind of installation to manage on this device.
-	Role Role `yaml:"role,omitempty"`
+	Role Role `yaml:"role,omitempty" json:"role,omitempty"`
 
 	// Options are arbitrary values the sdk may be interested in.  These values are not validated by C3OS and are simply forwarded to the sdk.
-	Options string `yaml:"config,omitempty"`
+	Options string `yaml:"config,omitempty" json:"config,omitempty"`
 }
 
 type Config struct {
-	Cluster *Cluster `yaml:"cluster,omitempty"`
+	Cluster *Cluster `yaml:"cluster,omitempty" json:"cluster,omitempty"`
 }


### PR DESCRIPTION
Cloud config is often written in yaml but go-pluggable and c3os do most of their serialization in json.  This was causing the config section of the cluster config to be lost.  I added support for serializing cluster objects as json and yaml.