### PR TITLE
Revert "Enable ubuntu to test pipelines"

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,7 +22,7 @@ jobs:
          - flavor: "opensuse"
          #- flavor: "tumbleweed"
          #- flavor: "fedora"
-         - flavor: "ubuntu"
+         #- flavor: "ubuntu"
          - flavor: "alpine"
     steps:
       - uses: actions/checkout@v2
@@ -101,8 +101,8 @@ jobs:
        include:
          - flavor: "opensuse"
          - flavor: "alpine"
-         - flavor: "ubuntu"
         # - flavor: "tumbleweed"
+#         - flavor: "ubuntu"
 #         - flavor: "fedora"
     steps:
       - uses: actions/checkout@v2
@@ -408,7 +408,6 @@ jobs:
        include:
          - flavor: "alpine"
          - flavor: "opensuse"
-         - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v2
     - name: Download artifacts


### PR DESCRIPTION
Reverts c3os-io/c3os#105

cc @vipsharm seems test are failing, disabling for now. better to debug them separately. did you tried the ISO? is it booting?